### PR TITLE
Add HTTP/3 support

### DIFF
--- a/background.js
+++ b/background.js
@@ -19,7 +19,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message === 'hq') {
     title = hqTitle
     icon = 'hq'
-  } else if (message.includes('quic')) {
+  } else if (message.includes('quic') || message.startsWith('h3')) {
     title = message
     icon = 'hq'
   } else {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "HTTP Indicator",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Indicator for HTTP/2 and QUIC support",
   "homepage_url": "https://github.com/pd4d10/http-indicator",
   "icons": {


### PR DESCRIPTION
Hi, we've made a change to Chrome that impacts the nextHopProtocol string that your extension uses. This PR should allow your extension to keep working with the change.

Full announcement here:
https://groups.google.com/a/chromium.org/forum/#!topic/net-dev/OOxSBYJjmN4